### PR TITLE
Remove padding on bottom of the menu

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -699,10 +699,6 @@ iframe {
   padding-bottom: 1em;
 }
 
-.panel-group {
-  padding-bottom: 1em;
-}
-
 .panel-title:active,
 .panel-title:active {
   color: #444;


### PR DESCRIPTION
It was annoying me that on mobile there was extra padding after the last menu category.
